### PR TITLE
Add documentation and issue tracker links to manifest.json

### DIFF
--- a/custom_components/ajax/manifest.json
+++ b/custom_components/ajax/manifest.json
@@ -6,6 +6,8 @@
   "codeowners": [],
   "requirements": [],
   "iot_class": "cloud_polling",
+  "documentation": "https://github.com/prismagroupsa/Ajax_alarm_ha_integration",
+  "issue_tracker": "https://github.com/prismagroupsa/Ajax_alarm_ha_integration/issues",
   "config_flow": true,
   "integration_type": "hub",
   "supported_platforms": ["sensor"]


### PR DESCRIPTION
Add links for documentation and known issues. These are linked to icons on the top right corner on the integration page in HA.